### PR TITLE
 Add Network Serialization Support

### DIFF
--- a/data/dataReader.java
+++ b/data/dataReader.java
@@ -7,11 +7,11 @@ import java.util.List;
 
 public class dataReader {
     //class to read mnist data from files into arrays
-    private final int rows = 28;
-    private final int cols = 28;
+    private static final int rows = 28;
+    private static final int cols = 28;
 
 
-    public List<Image> readData(String path)  {
+    public static List<Image> readData(String path)  {
 
     List<Image> Images = new ArrayList<>();
 

--- a/layer/Layer.java
+++ b/layer/Layer.java
@@ -1,10 +1,11 @@
 package layer;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 // Abstract base class for neural network layers. Handles core layer connections and utility functions.
-public abstract class Layer {
+public abstract class Layer implements Serializable  {
 
     // Reference to the next layer in the network.
     protected Layer nextLayer;

--- a/network/NetworkUtils.java
+++ b/network/NetworkUtils.java
@@ -1,0 +1,26 @@
+package network;
+
+import java.io.*;
+
+public class NetworkUtils {
+
+    public static void saveNetwork(NeuralNetwork network, String filePath) {
+        try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(filePath))) {
+            oos.writeObject(network);
+            System.out.println("Network saved to " + filePath);
+        } catch (IOException e) {
+            System.err.println("Error saving network: " + e.getMessage());
+        }
+    }
+
+    public static NeuralNetwork loadNetwork(String filePath) {
+        try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(filePath))) {
+            NeuralNetwork network = (NeuralNetwork) ois.readObject();
+            System.out.println("Network loaded from " + filePath);
+            return network;
+        } catch (IOException | ClassNotFoundException e) {
+            System.err.println("Error loading network: " + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/training/TrainNetwork.java
+++ b/training/TrainNetwork.java
@@ -33,9 +33,9 @@ public class TrainNetwork {
         float rate = net.test(imagesTest);
         System.out.println("Pre training success rate: " + rate);
 
-        int epochs = 5;
+        int epochs = 3;
 
-        for(int i = 0; i < epochs; i++){
+        for(int i = 1; i <= epochs; i++){
             shuffle(imagesTrain);
             net.train(imagesTrain);
             rate = net.test(imagesTest);

--- a/training/TrainNetwork.java
+++ b/training/TrainNetwork.java
@@ -3,6 +3,7 @@ package training;
 import data.Image;
 import data.dataReader;
 import network.NetworkBuilder;
+import network.NetworkUtils;
 import network.NeuralNetwork;
 
 import java.util.List;
@@ -15,9 +16,10 @@ public class TrainNetwork {
         long SEED = 123;
 
         System.out.println("Starting data loading...");
+        String networkFile = "saved_network.dat";
 
-        List<Image> imagesTest = new dataReader().readData("Data/mnist_test.csv");
-        List<Image> imagesTrain = new dataReader().readData("Data/mnist_train.csv");
+        List<Image> imagesTest = dataReader.readData("Data/mnist_test.csv");
+        List<Image> imagesTrain = dataReader.readData("Data/mnist_train.csv");
 
         System.out.println("Images Train size: " + imagesTrain.size());
         System.out.println("Images Test size: " + imagesTest.size());
@@ -28,17 +30,19 @@ public class TrainNetwork {
         builder.addFullyConnectedLayer(10, 0.1, SEED);
 
         NeuralNetwork net = builder.build();
-
         float rate = net.test(imagesTest);
         System.out.println("Pre training success rate: " + rate);
 
-        int epochs = 3;
+        int epochs = 5;
 
         for(int i = 0; i < epochs; i++){
             shuffle(imagesTrain);
             net.train(imagesTrain);
             rate = net.test(imagesTest);
             System.out.println("Success rate after round " + i + ": " + rate);
+            NetworkUtils.saveNetwork(net, networkFile); // Save after each epoch
+
+
         }
     }
 }


### PR DESCRIPTION

### Description:
- Implemented serialization for `NeuralNetwork` and its layers (`FullyConnectedLayer`, `MaxPoolLayer`).
- Added `NetworkUtils` class for saving (`saveNetwork`) and loading (`loadNetwork`) models.

### Changes:
- Made `NeuralNetwork` and all layers `Serializable`.
- Added methods to serialize and deserialize the network.

### How to Test:
1. Use `NetworkUtils.saveNetwork()` to save a trained model.
2. Load it with `NetworkUtils.loadNetwork()` and verify it loads correctly.
